### PR TITLE
feat: support all tags

### DIFF
--- a/toki/nanpa-kasi/o-pali-e-moku-telo-pan-brotzupa-wodzionka.md
+++ b/toki/nanpa-kasi/o-pali-e-moku-telo-pan-brotzupa-wodzionka.md
@@ -2,7 +2,7 @@
 nimi-suli: o pali e moku telo pan (Brotzupa, Wodzionka)
 jan-pali: jan Alonola
 tags:
-  - sona # moku
+  - moku
 ---
 
 o pali e moku telo pan (Brotzupa, Wodzionka)!

--- a/toki/nanpa-kule/moku-suwi-pa-tan-ma-petame.md
+++ b/toki/nanpa-kule/moku-suwi-pa-tan-ma-petame.md
@@ -2,7 +2,7 @@
 nimi-suli: moku suwi Pa tan ma Petame
 jan-pali: jan Ke Tami
 tags:
-  - sona # moku
+  - moku
 ---
 
 suwi Pa li moku suwi tan ma Petane (Bretagne) lon ma Kanse. mama mi li pali e ni tawa mi. mama ona li pali e ni tawa ona. suwi ni li pona mute tawa mi. ona li pini la, ona li sama pan suwi, li sama ko, li jo e kili lon insa.

--- a/toki/nanpa-soweli/akesi-poki-pi-noka-jelo.md
+++ b/toki/nanpa-soweli/akesi-poki-pi-noka-jelo.md
@@ -2,7 +2,7 @@
 nimi-suli: akesi poki pi noka jelo
 jan-pali: jan Alonola
 tags:
-  - sona # soweli
+  - soweli
 ---
 
 akesi poki Kelonowisi Tensikulatu (Chelonoidis denticulatus) li akesi poki pi noka jelo. akesi ni li jo e suli sama jan lili. selo poki li pimeja jelo anu pimeja loje. taso akesi ni li jo ala e selo poki pimeja. akesi poki pi noka jelo li jo e noka jelo e lawa jelo.

--- a/toki/nanpa-soweli/soweli-lili-suwi.md
+++ b/toki/nanpa-soweli/soweli-lili-suwi.md
@@ -2,7 +2,7 @@
 nimi-suli: soweli lili suwi
 jan-pali: jan Ke Tami
 tags:
-  - sona # soweli
+  - soweli
 ---
 
 mi pilin e ni: soweli li lili la, ona li suwi.

--- a/toki/nanpa-tenpo/kalama-pi-sitelen-nimi.md
+++ b/toki/nanpa-tenpo/kalama-pi-sitelen-nimi.md
@@ -2,7 +2,7 @@
 nimi-suli: kalama pi sitelen nimi
 jan-pali: jan Ke Tami
 tags:
-  - toki-pona
+  - toki pona
 ---
 nimi li jo e kalama. taso mi wile pana e kalama nimi ale tawa sina la sina ken sona kepeken nasin seme? mi o kalama seme e kalama lili ni? a, nasin mute li ken. mi ken pana e kalama taso: jan ni li jan Losu - kalama pi nimi ona li ni - L, O, S, U. taso ni li ken ike tawa sona kute. ni la mi o seme. lon la mi ken wawa e kalama. taso nasin ante li lon.
 

--- a/toki/nanpa-tenpo/sitelen-pona-li-ken-ala-ken-lon-nasin-Juniko.md
+++ b/toki/nanpa-tenpo/sitelen-pona-li-ken-ala-ken-lon-nasin-Juniko.md
@@ -2,7 +2,7 @@
 nimi-suli: sitelen pona li ken ala ken lon nasin Juniko
 jan-pali: jan Ke Tami
 tags:
-  - toki-pona
+  - toki pona
 ---
 nasin sitelen mute li ken e toki pi lipu ni. taso lon la, jan mute li kepeken nasin pi mute ala. ona li wile pana e toki ni tawa lipu la, ona pana e sitelen kepeken nasin Lasina anu nasin pali sin pi jan Sonja. nasin ni nanpa wan la, kalama wan li kama sitelen wan. nasin ni nanpa tu la, nimi wan li kama sitelen wan. nasin ni li pona mute tawa mi. taso ona li sin a. sin ona la, mi wile pana e sitelen kepeken ona tawa ilo sina la, mi kama ala kama ken? ike la, mi ken ala pana e ijo pi wile mi tawa ilo ale. taso ni li ken awen ala. ni li ken ante. nasin li ken e ante.
 

--- a/toki/toki.hbs
+++ b/toki/toki.hbs
@@ -11,7 +11,7 @@ categories:
   - name: kulupu
     collection: kulupu
   - name: toki pona
-    collection: toki-pona
+    collection: toki pona
   - name: sona
     collection: sona
   - name: ma
@@ -21,9 +21,25 @@ categories:
   - name: toki
     collection: toki-toki
   - name: toki ante
-    collection: toki-ante
+    collection: toki ante
   - name: musi
     collection: musi
+  - name: moku
+    collection: moku
+  - name: kijetesantakalu
+    collection: kijetesantakalu
+  - name: toki musi
+    collection: toki musi
+  - name: nasin lawa jan
+    collection: nasin lawa jan
+  - name: nimi
+    collection: nimi
+  - name: soweli
+    collection: soweli
+  - name: tenpo
+    collection: tenpo
+  - name: tenpo walo
+    collection: tenpo walo
 ---
 <div class="h2">
   <h2>


### PR DESCRIPTION
Old issues of lipu tenpo contained strange tags that were previously undocumented on the site. Including these tags in toki/toki.hbs is necessary to make articles searchable.

As most of these tags are extremely useless for organising articles across issues, we should consider going over all articles that use these tags and retroactively changing their tags to something more common.

(For the purposes of bringing your attention to these old tags, I have also un-commented some of those, like soweli.)